### PR TITLE
refs #104322 remove deprecated code

### DIFF
--- a/CameraSourceBindings/CameraSourceBindings.csproj
+++ b/CameraSourceBindings/CameraSourceBindings.csproj
@@ -12,7 +12,7 @@
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>CameraSourceBindings</AssemblyName>
     <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
-    <ReleaseVersion>0.6.0-beta</ReleaseVersion>
+    <ReleaseVersion>0.6.1-beta</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Rb.Forms.Barcode.Droid/Rb.Forms.Barcode.Droid.csproj
+++ b/Rb.Forms.Barcode.Droid/Rb.Forms.Barcode.Droid.csproj
@@ -14,7 +14,7 @@
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>Rb.Forms.Barcode.Droid</AssemblyName>
     <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
-    <ReleaseVersion>0.6.0-beta</ReleaseVersion>
+    <ReleaseVersion>0.6.1-beta</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Rb.Forms.Barcode.Pcl/Rb.Forms.Barcode.Pcl.csproj
+++ b/Rb.Forms.Barcode.Pcl/Rb.Forms.Barcode.Pcl.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>Rb.Forms.Barcode.Pcl</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
-    <ReleaseVersion>0.6.0-beta</ReleaseVersion>
+    <ReleaseVersion>0.6.1-beta</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Rb.Forms.Barcode.iOS/BarcodeScannerRenderer.cs
+++ b/Rb.Forms.Barcode.iOS/BarcodeScannerRenderer.cs
@@ -130,7 +130,7 @@ namespace Rb.Forms.Barcode.iOS
         private void startSession() 
         {
             session.StartRunning();
-            captureVideoPreviewLayer.Orientation = getDeviceOrientation();
+            captureVideoPreviewLayer.Connection.VideoOrientation = getDeviceOrientation();
             this.Debug("StartRunning");
             addOrientationObserver();
         }
@@ -201,7 +201,7 @@ namespace Rb.Forms.Barcode.iOS
             captureVideoPreviewLayer = AVCaptureVideoPreviewLayer.FromSession(session);
             captureVideoPreviewLayer.Frame = CGRect.Empty;
             captureVideoPreviewLayer.VideoGravity = AVLayerVideoGravity.ResizeAspectFill;
-            captureVideoPreviewLayer.Orientation = getDeviceOrientation();
+            captureVideoPreviewLayer.Connection.VideoOrientation = getDeviceOrientation();
 
             return true;
         }

--- a/Rb.Forms.Barcode.iOS/Rb.Forms.Barcode.iOS.csproj
+++ b/Rb.Forms.Barcode.iOS/Rb.Forms.Barcode.iOS.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Rb.Forms.Barcode.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Rb.Forms.Barcode.iOS</AssemblyName>
-    <ReleaseVersion>0.6.0-beta</ReleaseVersion>
+    <ReleaseVersion>0.6.1-beta</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Rb.Forms.Barcode.nuspec
+++ b/Rb.Forms.Barcode.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Rb.Forms.Barcode</id>
     <title>Barcode scanner plugin for Xamarin.Forms</title>
-    <version>0.6.0-beta</version>
+    <version>0.6.1-beta</version>
     <authors>Ota Mares</authors>
     <owners>reBuy reCommerce GmbH</owners>
     <licenseUrl>https://github.com/rebuy-de/rb-forms-barcode/blob/master/LICENSE</licenseUrl>
@@ -13,7 +13,10 @@
 
 Beta notice: Now with experimental iOS support.</description>
     <summary>Rb.Forms.Barcode is a Xamarin.Forms view for scanning barcodes.</summary>
-    <releaseNotes>0.6.0-beta: 
+    <releaseNotes>0.6.1-beta:
+* change: replace deprecated av orientation call
+    
+0.6.0-beta: 
 * New: add iOS support.
 * Public API should be nearly the same, only the config for iOS scanner is shorter than the Android config.
 </releaseNotes>

--- a/Rb.Forms.Barcode.sln
+++ b/Rb.Forms.Barcode.sln
@@ -182,6 +182,6 @@ Global
 		$2.inheritsSet = Mono
 		$2.inheritsScope = text/x-csharp
 		$2.scope = text/x-csharp
-		version = 0.6.0-beta
+		version = 0.6.1-beta
 	EndGlobalSection
 EndGlobal

--- a/Sample.iOS/Sample.iOS.csproj
+++ b/Sample.iOS/Sample.iOS.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Sample.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Sample.iOS</AssemblyName>
-    <ReleaseVersion>0.6.0-beta</ReleaseVersion>
+    <ReleaseVersion>0.6.1-beta</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Sample/Sample.Droid/Sample.Droid.csproj
+++ b/Sample/Sample.Droid/Sample.Droid.csproj
@@ -16,7 +16,7 @@
     <AssemblyName>Sample.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v5.1</TargetFrameworkVersion>
-    <ReleaseVersion>0.6.0-beta</ReleaseVersion>
+    <ReleaseVersion>0.6.1-beta</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Sample/Sample.Pcl/Sample.Pcl.csproj
+++ b/Sample/Sample.Pcl/Sample.Pcl.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>Sample.Pcl</AssemblyName>
     <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <ReleaseVersion>0.6.0-beta</ReleaseVersion>
+    <ReleaseVersion>0.6.1-beta</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
@rebuy-de/it-mobile 
overlook to remove the deprecated orientation code. it was outdated because a other change was in the same line.